### PR TITLE
fix: add account name to connection example

### DIFF
--- a/src/main/java/path/e12_connections/AccountAccessor.java
+++ b/src/main/java/path/e12_connections/AccountAccessor.java
@@ -2,6 +2,7 @@ package path.e12_connections;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.mx.path.core.common.accessor.PathResponseStatus;
@@ -18,6 +19,8 @@ import com.mx.path.model.mdx.model.account.Account;
 
 import path.e12_connections.bank.BankConnection;
 import path.e12_connections.bank.models.BankAccount;
+import path.e12_connections.bank.models.BankAccountSubType;
+import path.e12_connections.bank.models.BankAccountType;
 
 @MaxScope(AccessorScope.SINGLETON)
 public class AccountAccessor extends AccountBaseAccessor {
@@ -31,8 +34,20 @@ public class AccountAccessor extends AccountBaseAccessor {
 
   @Override
   public final AccessorResponse<MdxList<Account>> list() {
-    List<BankAccount> accounts = connection.getAccounts(Session.current().getUserId());
-    MdxList<Account> mdxAccounts = accounts.stream().map(bankAccount -> {
+    String customerId = Session.current().getUserId();
+
+    List<BankAccount> accounts = connection.getAccounts(customerId);
+    MdxList<Account> mdxAccounts = mapToMdxAccounts(accounts);
+
+    return new AccessorResponse<MdxList<Account>>()
+        .withResult(mdxAccounts)
+        .withStatus(PathResponseStatus.OK);
+  }
+
+  private MdxList<Account> mapToMdxAccounts(List<BankAccount> accounts) {
+    Map<String, BankAccountSubType> accountSubTypeToType = loadBankAccountSubtypes();
+
+    return accounts.stream().map(bankAccount -> {
       Account mdxAccount = new Account();
       mdxAccount.setId(bankAccount.getId());
       mdxAccount.setAccountNumber(bankAccount.getAccountNumber());
@@ -42,11 +57,29 @@ public class AccountAccessor extends AccountBaseAccessor {
         mdxAccount.setAvailableBalance(BigDecimal.valueOf(Double.parseDouble(bankAccount.getAvailableBalance())));
       }
 
+      BankAccountSubType accountType = accountSubTypeToType.get(bankAccount.getAccountSubtypeId());
+      mdxAccount.setName(accountType.getAccountType().getAccountTypeName() + " - " + accountType.getAccountSubtypeName());
+
       return mdxAccount;
     }).collect(Collectors.toCollection(MdxList::new));
+  }
 
-    return new AccessorResponse<MdxList<Account>>()
-        .withResult(mdxAccounts)
-        .withStatus(PathResponseStatus.OK);
+  /**
+   * This is very inefficient. The data retrieved here is mostly static for the client.
+   * We will look at a way to improve this by using Facilities in example13.
+   *
+   * @return map of accountSubtypeId -> accountSubtype
+   */
+  private Map<String, BankAccountSubType> loadBankAccountSubtypes() {
+    // Load all account types
+    List<BankAccountType> accountTypes = connection.getAccountTypes();
+
+    // Load all account subtypes, map them to the account_type, and place them in hash by id.
+    return accountTypes.stream().flatMap(accountType -> {
+      return connection.getAccountSubTypes(accountType.getId()).stream().map(accountSubType -> {
+        accountSubType.setAccountType(accountType);
+        return accountSubType;
+      });
+    }).collect(Collectors.toMap(BankAccountSubType::getId, bankAccountSubType -> bankAccountSubType));
   }
 }

--- a/src/main/java/path/e12_connections/Main.java
+++ b/src/main/java/path/e12_connections/Main.java
@@ -29,6 +29,7 @@ public class Main {
     @Subscribe
     public final void afterRequest(AfterUpstreamRequestEvent event) {
       System.out.println("\nREQUEST --------------------------------------");
+      System.out.println("  URI: [" + event.getRequest().getMethod() + "] " + event.getRequest().getUri());
       System.out.println("  Status: " + event.getResponse().getStatus());
       System.out.println("  Body:" + event.getResponse().getBody());
       System.out.println("----------------------------------------------");

--- a/src/main/java/path/e12_connections/bank/BankConnection.java
+++ b/src/main/java/path/e12_connections/bank/BankConnection.java
@@ -9,13 +9,14 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mx.path.connect.http.HttpAccessorConnection;
 import com.mx.path.connect.http.HttpRequest;
-import com.mx.path.connect.http.HttpResponse;
 import com.mx.path.core.common.accessor.PathResponseStatus;
 import com.mx.path.core.common.configuration.Configuration;
 import com.mx.path.core.common.connect.UpstreamErrorException;
 import com.mx.path.core.common.http.HttpStatus;
 
 import path.e12_connections.bank.models.BankAccount;
+import path.e12_connections.bank.models.BankAccountSubType;
+import path.e12_connections.bank.models.BankAccountType;
 
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public class BankConnection extends HttpAccessorConnection {
@@ -27,9 +28,8 @@ public class BankConnection extends HttpAccessorConnection {
     this.configuration = connectionConfiguration;
   }
 
-  @SuppressWarnings("unchecked")
   public final List<BankAccount> getAccounts(String customerId) {
-    HttpResponse response = request("customers/" + customerId + "/accounts")
+    return request("customers/" + customerId + "/accounts")
         .withProcessor((resp) -> {
           BankAccount.BankAccounts accounts = gson.fromJson(resp.getBody(), BankAccount.BankAccounts.class);
           return accounts.getAccounts();
@@ -39,9 +39,54 @@ public class BankConnection extends HttpAccessorConnection {
             throw new UpstreamErrorException("Failed to get accounts", resp.getStatus(), PathResponseStatus.UNAVAILABLE);
           }
         })
-        .get();
+        .get()
+        .throwException()
+        .getObject();
+  }
 
-    return response.getObject();
+  public final BankAccount getAccount(String customerId, String accountId) {
+    return request("customers/" + customerId + "/accounts/" + accountId)
+        .withProcessor((resp) -> gson.fromJson(resp.getBody(), BankAccount.class))
+        .withOnComplete((resp) -> {
+          if (resp.getStatus() != HttpStatus.OK) {
+            throw new UpstreamErrorException("Failed to get accounts", resp.getStatus(), PathResponseStatus.UNAVAILABLE);
+          }
+        })
+        .get()
+        .throwException()
+        .getObject();
+  }
+
+  public final List<BankAccountType> getAccountTypes() {
+    return request("administration/account_types")
+        .withProcessor((resp) -> {
+          BankAccountType.BankAccountTypes accounts = gson.fromJson(resp.getBody(), BankAccountType.BankAccountTypes.class);
+          return accounts.getAccountTypes();
+        })
+        .withOnComplete((resp) -> {
+          if (resp.getStatus() != HttpStatus.OK) {
+            throw new UpstreamErrorException("Failed to get accounts", resp.getStatus(), PathResponseStatus.UNAVAILABLE);
+          }
+        })
+        .get()
+        .throwException()
+        .getObject();
+  }
+
+  public final List<BankAccountSubType> getAccountSubTypes(String accountTypeId) {
+    return request("administration/account_types/" + accountTypeId + "/account_subtypes")
+        .withProcessor((resp) -> {
+          BankAccountSubType.BankAccountSubTypes accounts = gson.fromJson(resp.getBody(), BankAccountSubType.BankAccountSubTypes.class);
+          return accounts.getAccountSubtypes();
+        })
+        .withOnComplete((resp) -> {
+          if (resp.getStatus() != HttpStatus.OK) {
+            throw new UpstreamErrorException("Failed to get accounts", resp.getStatus(), PathResponseStatus.UNAVAILABLE);
+          }
+        })
+        .get()
+        .throwException()
+        .getObject();
   }
 
   @Override

--- a/src/main/java/path/e12_connections/bank/models/BankAccount.java
+++ b/src/main/java/path/e12_connections/bank/models/BankAccount.java
@@ -13,6 +13,7 @@ public class BankAccount {
   private String accountStatus;
   private String currentBalance;
   private String availableBalance;
+  private String accountSubtypeId;
 
   @Data
   public static class BankAccounts {

--- a/src/main/java/path/e12_connections/bank/models/BankAccountSubType.java
+++ b/src/main/java/path/e12_connections/bank/models/BankAccountSubType.java
@@ -1,0 +1,20 @@
+package path.e12_connections.bank.models;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class BankAccountSubType {
+  private String id;
+  private String accountTypeId;
+  private String accountSubtypeName;
+  private String accountSubtypeAbbreviation;
+
+  private BankAccountType accountType;
+
+  @Data
+  public static class BankAccountSubTypes {
+    private List<BankAccountSubType> accountSubtypes;
+  }
+}

--- a/src/main/java/path/e12_connections/bank/models/BankAccountType.java
+++ b/src/main/java/path/e12_connections/bank/models/BankAccountType.java
@@ -1,0 +1,17 @@
+package path.e12_connections.bank.models;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class BankAccountType {
+  private String id;
+  private String accountTypeName;
+  private String accountTypeAbbreviation;
+
+  @Data
+  public static class BankAccountTypes {
+    private List<BankAccountType> accountTypes;
+  }
+}


### PR DESCRIPTION
This calls `account_types` and `account_subtypes` endpoints to load the account type and uses that to set the account name.